### PR TITLE
👌 IMPROVE: Skip missing interpreters to True locally

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,4 +26,4 @@ jobs:
         pip install tox
     - name: Test with tox
       run: |
-        tox -e py
+        tox --skip-missing-interpreters=false -e py

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         pyenv local 3.6.9 3.7.4 3.8.0
         ./cc-test-reporter before-build
-        tox
+        tox --skip-missing-interpreters=false
         ./cc-test-reporter after-build --coverage-input-type coverage.py --exit-code $?
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODECLIMATE_REPORTER_ID }}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist=clean,py{36,37,38},report
+skip_missing_interpreters=True
 
 [testenv]
 commands=


### PR DESCRIPTION
Basically the tox team does this as well https://github.com/tox-dev/tox/issues/903#issuecomment-404122691

Setting it to True by default means we don't need every interpreter installed locally. But we explicitly set this to false when running on CI to ensure we do actually test on every version.