### PR TITLE
🐛 FIX: Revert isolated builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,0 @@
-[build-system]
-requires = [
-  "setuptools==47.1.1",
-  "setuptools_scm==3.3.3",
-]
-build-backend="setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         "requests>=2.23.0",
         "websocket_client>=0.57.0",
     ],
+    setup_requires=["setuptools-scm==3.3.3"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,6 @@
 [tox]
 envlist=clean,py{36,37,38},report
 skip_missing_interpreters=True
-isolated_build=True
 
 [testenv]
 commands=


### PR DESCRIPTION
As per https://github.com/pypa/setuptools_scm/issues/386 setuptools_scm in pyproject.toml has some funky behavior. Since isolated builds was probably not the solution to [what they tried to solve](https://github.com/tox-dev/tox/issues/1600), reverting this.